### PR TITLE
Replacing time.clock with time.perf_counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ https://file.io/uRglUT
 
 ### Changelog
 
+#### v1.0.2
+
+* Replaced `time.clock` (removed in python 3.8) with `time.perf_counter`
+
 #### v1.0.1
 
 * Add `-t, --tar` and `-z, --gzip` options

--- a/file_io_cli.py
+++ b/file_io_cli.py
@@ -151,9 +151,9 @@ class ProgressDisplay(object):
     self.last_print = None
 
   def update(self, n_read, force=False):
-    if not force and self.last_print is not None and time.clock() - self.last_print < 0.25:
+    if not force and self.last_print is not None and time.perf_counter() - self.last_print < 0.25:
       return
-    self.last_print = time.clock()
+    self.last_print = time.perf_counter()
     self.__clear_line(file=sys.stderr)
     if self.n_max is None:
       c = self.SPINCHARS[self.alteration%len(self.SPINCHARS)]


### PR DESCRIPTION
`time.clock` has been [deprecated since python 3.3, removed since 3.8](https://docs.python.org/3.7/library/time.html?highlight=deprecated%20removed#time.clock) because of its platform-dependent behaviour. This PR replaces it with `time.perf_counter()`.